### PR TITLE
rename from init-charts to sbat-cd

### DIFF
--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -17,7 +17,7 @@ spec:
       - name: externalCert.projectId
         value: {{ .Values.config.externalCert.projectId }}
     path: cluster-setup/namespace-setup
-    repoURL: https://github.com/SecureBankingAccessToolkit/init-charts
+    repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}
   syncPolicy:
     {{- if .Values.spec.syncPolicy }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -4,7 +4,6 @@ spec:
     server: https://kubernetes.default.svc
     namespace: dev
   source:
-    repoURL: https://github.com/SecureBankingAccessToolkit/init-charts
     targetRevision: HEAD
 
   syncPolicy: {}


### PR DESCRIPTION
init-charts repo has been renamed to sbat-cd, some of the config must change to reflect this.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/16