### PR TITLE
add the securebanking argo application manifest

### DIFF
--- a/argo/apps/templates/securebanking-ui.yaml
+++ b/argo/apps/templates/securebanking-ui.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: securebanking-ui-{{ .Release.Name }}
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: {{ .Values.spec.destination.namespace }}
+    server: {{ .Values.spec.destination.server }}
+  project: {{ .Values.spec.project }}
+  source:
+    helm:
+      parameters:
+      - name: ingress.domain
+        value: {{ .Values.config.domain }}
+    path: _infra/helm/securebanking-ui
+    repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-ui
+    targetRevision: {{ .Values.spec.source.targetRevision }}
+  syncPolicy:
+    {{- toYaml .Values.spec.syncPolicy | nindent 4 }}


### PR DESCRIPTION
Add the Application manifest for argo to monitor and deploy the securebanking-ui into the `dev` cluster/namespace.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/17