### PR TITLE
disable auth by default for the dev namespace

### DIFF
--- a/argo/apps/templates/mongodb.yaml
+++ b/argo/apps/templates/mongodb.yaml
@@ -12,6 +12,9 @@ spec:
     helm:
       valueFiles:
       - values.yaml
+      parameters:
+      - name: auth.enabled
+        value: "{{ .Values.mongodb.auth.enabled }}"
     repoURL: https://charts.bitnami.com/bitnami
     targetRevision: 10.15.1
   syncPolicy:

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -12,3 +12,7 @@ config:
   domain: localhost
   externalCert:
     projectId: example-project
+
+mongodb:
+  auth:
+    enabled: false


### PR DESCRIPTION
authentication is not required for local development/ dev cluster.
it has been disabled via argo.