### PR TITLE
synchronize applications with branch

### DIFF
--- a/argo/workflows/sync-and-wait.yaml
+++ b/argo/workflows/sync-and-wait.yaml
@@ -22,7 +22,7 @@ spec:
       - name: namespace
       - name: tag
         value: latest
-      - name: revision
+      - name: branch
         value: HEAD
       - name: flags
         value: --
@@ -45,7 +45,7 @@ spec:
 
         set -euo pipefail
         argocd app set {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} -p deployment.imageOverride.tag={{inputs.parameters.tag}}
-        argocd app sync {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --revision {{inputs.parameters.revision}} {{inputs.parameters.flags}}
+        argocd app sync {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --revision {{inputs.parameters.branch}} {{inputs.parameters.flags}}
         argocd app wait {{inputs.parameters.application-name}}-{{inputs.parameters.namespace}} --health {{inputs.parameters.flags}}
   
   - name: sync-helm

--- a/argo/workflows/sync-application.yaml
+++ b/argo/workflows/sync-application.yaml
@@ -11,6 +11,8 @@ spec:
       - name: application-name
       - name: tag
         value: latest
+      - name: branch
+        value: HEAD
 
   templates:
   - name: sync-application
@@ -27,6 +29,8 @@ spec:
             value: "{{workflow.parameters.tag}}"
           - name: namespace
             value: "{{workflow.parameters.namespace}}"
+          - name: branch
+            value: "{{workflow.parameters.branch}}"
 
   - name: sync-git
     inputs:
@@ -34,6 +38,7 @@ spec:
       - name: application-name
       - name: tag
       - name: namespace
+      - name: branch
     steps:                              # You should only reference external "templates" in a "steps" or "dag" "template".
       - - name: sync
           templateRef:                  # You can reference a "template" from another "WorkflowTemplate or ClusterWorkflowTemplate" using this field
@@ -47,4 +52,6 @@ spec:
               value: "{{inputs.parameters.tag}}"
             - name: namespace
               value: "{{inputs.parameters.namespace}}"
+            - name: branch
+              value: "{{inputs.parameters.branch}}"
   


### PR DESCRIPTION
Add `branch` configuration to the sync workflows.
This will allows us to synchronise applications on specific branches during the PR phase allowing us to perform functional/deployment tests before merge.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/21