### PR TITLE
Apply new config for dev envs

### DIFF
--- a/argo/apps/templates/mongodb.yaml
+++ b/argo/apps/templates/mongodb.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: mongodb-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/hook: PreSync
 spec:
   destination:
     namespace: {{ .Values.spec.destination.namespace }}

--- a/argo/apps/templates/securebanking-rcs.yaml
+++ b/argo/apps/templates/securebanking-rcs.yaml
@@ -14,6 +14,8 @@ spec:
       parameters:
       - name: ingress.domain
         value: {{ .Values.config.domain }}
+      - name: deployment.imageOverride.tag
+        value: {{ .Values.tag.api.rcs }}
     path: _infra/helm/securebanking-openbanking-uk-rcs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rcs
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/templates/securebanking-rcs.yaml
+++ b/argo/apps/templates/securebanking-rcs.yaml
@@ -13,7 +13,7 @@ spec:
     helm:
       parameters:
       - name: ingress.domain
-        value: {{ .Values.config.domain }}
+        value: {{ .Values.ingress.domain }}
       - name: deployment.imageOverride.tag
         value: {{ .Values.tag.api.rcs }}
     path: _infra/helm/securebanking-openbanking-uk-rcs

--- a/argo/apps/templates/securebanking-rs.yaml
+++ b/argo/apps/templates/securebanking-rs.yaml
@@ -13,7 +13,7 @@ spec:
     helm:
       parameters:
       - name: ingress.domain
-        value: {{ .Values.config.domain }}
+        value: {{ .Values.ingress.domain }}
       - name: deployment.imageOverride.tag
         value: {{ .Values.tag.api.rs }}
     path: _infra/helm/securebanking-openbanking-uk-rs

--- a/argo/apps/templates/securebanking-rs.yaml
+++ b/argo/apps/templates/securebanking-rs.yaml
@@ -14,6 +14,8 @@ spec:
       parameters:
       - name: ingress.domain
         value: {{ .Values.ingress.domain }}
+      - name: mongodb.host
+        value: "mongodb-{{ .Release.Name }}"
       - name: deployment.imageOverride.tag
         value: {{ .Values.tag.api.rs }}
     path: _infra/helm/securebanking-openbanking-uk-rs

--- a/argo/apps/templates/securebanking-rs.yaml
+++ b/argo/apps/templates/securebanking-rs.yaml
@@ -14,6 +14,8 @@ spec:
       parameters:
       - name: ingress.domain
         value: {{ .Values.config.domain }}
+      - name: deployment.imageOverride.tag
+        value: {{ .Values.tag.api.rs }}
     path: _infra/helm/securebanking-openbanking-uk-rs
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/templates/securebanking-ui.yaml
+++ b/argo/apps/templates/securebanking-ui.yaml
@@ -14,6 +14,12 @@ spec:
       parameters:
       - name: ingress.domain
         value: {{ .Values.config.domain }}
+      - name: auth.deployment.imageOverride.tag
+        value: {{ .Values.tag.ui.auth }}
+      - name: rcs.deployment.imageOverride.tag
+        value: {{ .Values.tag.ui.rcs }}
+      - name: swagger.deployment.imageOverride.tag
+        value: {{ .Values.tag.ui.swagger }}
     path: _infra/helm/securebanking-ui
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-ui
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/templates/securebanking-ui.yaml
+++ b/argo/apps/templates/securebanking-ui.yaml
@@ -13,7 +13,7 @@ spec:
     helm:
       parameters:
       - name: ingress.domain
-        value: {{ .Values.config.domain }}
+        value: {{ .Values.ingress.domain }}
       - name: auth.deployment.imageOverride.tag
         value: {{ .Values.tag.ui.auth }}
       - name: rcs.deployment.imageOverride.tag

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -6,7 +6,8 @@ spec:
   source:
     targetRevision: HEAD
 
-  syncPolicy: {}
+  syncPolicy: 
+    automated: {}
 
 ingress:
   domain: localhost

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -8,10 +8,8 @@ spec:
 
   syncPolicy: {}
 
-config:
+ingress:
   domain: localhost
-  externalCert:
-    projectId: example-project
 
 tag:
   ui:

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -13,6 +13,15 @@ config:
   externalCert:
     projectId: example-project
 
+tag:
+  ui:
+    auth: latest
+    rcs: latest
+    swagger: latest
+  api:
+    rcs: latest
+    rs: latest
+
 mongodb:
   auth:
     enabled: false

--- a/argo/parent-app/templates/applications.yaml
+++ b/argo/parent-app/templates/applications.yaml
@@ -13,17 +13,7 @@ spec:
     helm:
       parameters:
       - name: ingress.domain
-        value: {{ .Values.config.domain }}
-      # - name: auth.deployment.imageOverride.tag
-      #   value: {{ .Values.tag.ui.auth }}
-      # - name: rcs.deployment.imageOverride.tag
-      #   value: {{ .Values.tag.ui.rcs }}
-      # - name: swagger.deployment.imageOverride.tag
-      #   value: {{ .Values.tag.ui.swagger }}
-      # - name: auth.deployment.imageOverride.tag
-      #   value: {{ .Values.tag.api.rs }}
-      # - name: rcs.deployment.imageOverride.tag
-      #   value: {{ .Values.tag.api.rcs }}
+        value: {{ .Values.ingress.domain }}
     path: argo/apps
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/parent-app/templates/applications.yaml
+++ b/argo/parent-app/templates/applications.yaml
@@ -10,6 +10,20 @@ spec:
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
+    helm:
+      parameters:
+      - name: ingress.domain
+        value: {{ .Values.config.domain }}
+      # - name: auth.deployment.imageOverride.tag
+      #   value: {{ .Values.tag.ui.auth }}
+      # - name: rcs.deployment.imageOverride.tag
+      #   value: {{ .Values.tag.ui.rcs }}
+      # - name: swagger.deployment.imageOverride.tag
+      #   value: {{ .Values.tag.ui.swagger }}
+      # - name: auth.deployment.imageOverride.tag
+      #   value: {{ .Values.tag.api.rs }}
+      # - name: rcs.deployment.imageOverride.tag
+      #   value: {{ .Values.tag.api.rcs }}
     path: argo/apps
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/parent-app/values.yaml
+++ b/argo/parent-app/values.yaml
@@ -6,22 +6,8 @@ spec:
   source:
     targetRevision: HEAD
 
-config:
+ingress:
   domain: localhost
-
-securebanking-rcs-dev:
-  deployment:
-    imageOverride:
-      tag: test-pr
-      
-tag:
-  ui:
-    auth: latest
-    rcs: latest
-    swagger: latest
-  api:
-    rcs: latest
-    rs: latest
 
 externalCert:
   projectId: example-project

--- a/argo/parent-app/values.yaml
+++ b/argo/parent-app/values.yaml
@@ -6,5 +6,22 @@ spec:
   source:
     targetRevision: HEAD
 
+config:
+  domain: localhost
+
+securebanking-rcs-dev:
+  deployment:
+    imageOverride:
+      tag: test-pr
+      
+tag:
+  ui:
+    auth: latest
+    rcs: latest
+    swagger: latest
+  api:
+    rcs: latest
+    rs: latest
+
 externalCert:
   projectId: example-project


### PR DESCRIPTION
Apply image tags to the child apps so we can easily set test containers.
Apply the presync hook to the mongodb so the resources can remain if the argo application is destroyed.
change `config.domain` to `ingress.domain`
Apply mongodb host based on the helm chart release name.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/21