### PR TITLE
move namespace to apps

### DIFF
--- a/argo/apps/templates/mongodb.yaml
+++ b/argo/apps/templates/mongodb.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: mongodb-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
 spec:
   destination:
     namespace: {{ .Values.spec.destination.namespace }}

--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -3,12 +3,12 @@ kind: Application
 metadata:
   name: namespace-setup-{{ .Release.Name }}
   annotations:
-    argocd.argoproj.io/hook: PreSync
+    argocd.argoproj.io/sync-wave: "1"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:
   destination:
-    namespace: {{ .Release.Name }}
+    namespace: {{ .Values.spec.destination.namespace }}
     server: {{ .Values.spec.destination.server }}
   project: {{ .Values.spec.project }}
   source:
@@ -20,6 +20,8 @@ spec:
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}
   syncPolicy:
-    automated: {}
+    automated:
+      selfHeal: true
+      prune: true
     syncOptions:
       - CreateNamespace=true

--- a/argo/apps/templates/securebaking-spring-config-server.yaml
+++ b/argo/apps/templates/securebaking-spring-config-server.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: config-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/templates/securebanking-rcs.yaml
+++ b/argo/apps/templates/securebanking-rcs.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: rcs-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/templates/securebanking-rs.yaml
+++ b/argo/apps/templates/securebanking-rs.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: rs-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "3"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/templates/securebanking-ui.yaml
+++ b/argo/apps/templates/securebanking-ui.yaml
@@ -2,6 +2,8 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: ui-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
   finalizers:
   - resources-finalizer.argocd.argoproj.io
 spec:

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -30,3 +30,6 @@ ui:
 mongodb:
   auth:
     enabled: false
+
+externalCert:
+  projectId: example-project


### PR DESCRIPTION
Move the namespace setup to the parent app and ensure that it is self healing, this way the namespace and services will always repair themselves. A fresh environment can be created by simply deleting the namespace and waiting for the repair.
