### PR TITLE
remove init namesapce from the workflow

### DIFF
--- a/argo/workflows/environment-creation.yaml
+++ b/argo/workflows/environment-creation.yaml
@@ -23,14 +23,6 @@ spec:
           - name: namespace
             value: "{{workflow.parameters.namespace}}"
         when: "{{workflow.parameters.clean}}"
-    - - name: init-namespace
-        template: sync-git
-        arguments:
-          parameters:
-          - name: parent-name
-            value: namespace-setup
-          - name: namespace
-            value: "{{workflow.parameters.namespace}}"
     - - name: sync-parent-app
         template: sync-git
         arguments:

--- a/argo/workflows/slack-rebuild-notify.yaml
+++ b/argo/workflows/slack-rebuild-notify.yaml
@@ -28,7 +28,9 @@ spec:
             secretKeyRef:
               name: slack-webhook
               key: url
+        - name: DOMAIN
+          value: forgerock.financial
       source: |
         #!/bin/sh
-        SLACK_MESSAGE=$(echo 'Environment built successfully! \n namespace: `{{inputs.parameters.namespace}}`')
+        SLACK_MESSAGE=$(echo "sbat-dev environment building in the `{{inputs.parameters.namespace}}` namespace \n\n rs: `rs.{{inputs.parameters.namespace}}.$DOMAIN`\n rcs: `rcs.{{inputs.parameters.namespace}}.$DOMAIN`\n rcs-ui: `rcs-ui.{{inputs.parameters.namespace}}.$DOMAIN`\n auth-ui: `auth.{{inputs.parameters.namespace}}.$DOMAIN`\n swagger-ui: `swagger.{{inputs.parameters.namespace}}.$DOMAIN`")
         curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"$SLACK_MESSAGE\"}" $SLACK_WEBHOOK_URL


### PR DESCRIPTION
Init namespace is no longer required in the workflow. this is done automatically by the parent app.
give more slack information on an environment when it has been built.