### PR TITLE
different certs based on namesapce

### DIFF
--- a/cluster-setup/namespace-setup/README.md
+++ b/cluster-setup/namespace-setup/README.md
@@ -5,6 +5,6 @@ This helm chart has the purpose of bringing an SSL certificate from the google s
 
 | Value | description | default |
 | ----- | ----------- | ------- |
-| externalCert.enabled | enable wildcard certificate | `true` |
+| externalCert.defaultWildcard | enable the default wildcard certificate relevant for the `dev` domain | `true` |
 | externalCert.secretName | Name of the kubernetes secret to store the wildcard | `sslcert` |
 | externalCert.projectId | GCP project that stores the secrets | `example-project` |

--- a/cluster-setup/namespace-setup/templates/wildcard-secret.yaml
+++ b/cluster-setup/namespace-setup/templates/wildcard-secret.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.externalCert.enabled }}
 apiVersion: kubernetes-client.io/v1
 kind: ExternalSecret
 metadata:
@@ -9,10 +8,18 @@ spec:
     type: kubernetes.io/tls
   projectId: {{ .Values.externalCert.projectId }}
   data:
+    {{- if .Values.externalCert.defaultWildcard }}
     - key: wildcard-crt
       name: tls.crt
       version: latest
     - key: wildcard-key
       name: tls.key
       version: latest
-{{- end }}
+    {{- else }}
+    - key: {{ .Release.Namespace }}-crt
+      name: tls.crt
+      version: latest
+    - key: {{ .Release.Namespace }}-key
+      name: tls.key
+      version: latest
+    {{- end }}

--- a/cluster-setup/namespace-setup/values.yaml
+++ b/cluster-setup/namespace-setup/values.yaml
@@ -1,10 +1,6 @@
 serviceAccount: default
 
-imageRepoSecret:
-  namespace: default
-  name: gcr-secret
-
 externalCert:
-  enabled: true
+  defaultWildcard: true
   projectId: example-project
   secretName: sslcert


### PR DESCRIPTION
Allows us to select a certificate based on the namespace we are deploying into. Defaults to the basic wildcard.
Cert selected by the namespace that the chart deploys into.

Remove unneeded config.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/21