### PR TITLE
add parameter to set the defaultWildcard in argo

### DIFF
--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -16,6 +16,8 @@ spec:
       parameters:
       - name: externalCert.projectId
         value: {{ .Values.externalCert.projectId }}
+      - name: externalCert.defaultWildcard
+        value: {{ .Values.externalCert.defaultWildcard }}
     path: cluster-setup/namespace-setup
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -33,3 +33,4 @@ mongodb:
 
 externalCert:
   projectId: example-project
+  defaultWildcard: true

--- a/argo/parent-app/templates/applications.yaml
+++ b/argo/parent-app/templates/applications.yaml
@@ -15,7 +15,9 @@ spec:
       - name: ingress.domain
         value: {{ .Values.ingress.domain }}
       - name: externalCert.projectId
-        value: {{ .Values.externalCert.projectId}}
+        value: {{ .Values.externalCert.projectId }}
+      - name: externalCert.defaultWildcard
+        value: {{ .Values.externalCert.defaultWildcard }}
       - name: spec.destination.namespace
         value: {{ .Release.Name }}
     path: argo/apps

--- a/argo/parent-app/values.yaml
+++ b/argo/parent-app/values.yaml
@@ -11,3 +11,4 @@ ingress:
 
 externalCert:
   projectId: example-project
+  defaultWildcard: true


### PR DESCRIPTION
add parameter to set the default wildcard certificate for the argo applications.

issue: https://github.com/SecureBankingAccessToolkit/sbat-cd/issues/21