### PR TITLE
Fix quote

### DIFF
--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -17,7 +17,7 @@ spec:
       - name: externalCert.projectId
         value: {{ .Values.externalCert.projectId }}
       - name: externalCert.defaultWildcard
-        value: {{ .Values.externalCert.defaultWildcard }}
+        value: {{ .Values.externalCert.defaultWildcard | quote }}
     path: cluster-setup/namespace-setup
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/argo/parent-app/templates/applications.yaml
+++ b/argo/parent-app/templates/applications.yaml
@@ -17,7 +17,7 @@ spec:
       - name: externalCert.projectId
         value: {{ .Values.externalCert.projectId }}
       - name: externalCert.defaultWildcard
-        value: {{ .Values.externalCert.defaultWildcard }}
+        value: {{ .Values.externalCert.defaultWildcard | quote }}
       - name: spec.destination.namespace
         value: {{ .Release.Name }}
     path: argo/apps

--- a/argo/parent-app/values.yaml
+++ b/argo/parent-app/values.yaml
@@ -4,7 +4,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: argocd
   source:
-    targetRevision: fix-quote
+    targetRevision: HEAD
 
 ingress:
   domain: localhost

--- a/argo/parent-app/values.yaml
+++ b/argo/parent-app/values.yaml
@@ -4,7 +4,7 @@ spec:
     server: https://kubernetes.default.svc
     namespace: argocd
   source:
-    targetRevision: HEAD
+    targetRevision: fix-quote
 
 ingress:
   domain: localhost

--- a/cluster-setup/namespace-setup/templates/wildcard-secret.yaml
+++ b/cluster-setup/namespace-setup/templates/wildcard-secret.yaml
@@ -8,7 +8,7 @@ spec:
     type: kubernetes.io/tls
   projectId: {{ .Values.externalCert.projectId }}
   data:
-    {{- if .Values.externalCert.defaultWildcard }}
+    {{- if eq .Values.externalCert.defaultWildcard "true" }}
     - key: wildcard-crt
       name: tls.crt
       version: latest

--- a/cluster-setup/namespace-setup/values.yaml
+++ b/cluster-setup/namespace-setup/values.yaml
@@ -1,6 +1,6 @@
 serviceAccount: default
 
 externalCert:
-  defaultWildcard: true
+  defaultWildcard: "true"
   projectId: example-project
   secretName: sslcert


### PR DESCRIPTION
Argo application helm parameters are string only. Boolean will not work, our bool values here must be converted to strings and and a string comparison on the external secret is required.
