### PR TITLE
Cmd enabled

### DIFF
--- a/argo/apps/templates/iam-init.yaml
+++ b/argo/apps/templates/iam-init.yaml
@@ -1,0 +1,29 @@
+{{- if eq .Values.cdm.enabled "true" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: iam-{{ .Release.Name }}
+  annotations:
+    argocd.argoproj.io/sync-wave: "2"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: {{ .Values.spec.destination.namespace }}
+    server: {{ .Values.spec.destination.server }}
+  project: {{ .Values.spec.project }}
+  source:
+    helm:
+      parameters:
+      - name: ingress.domain
+        value: {{ .Values.ingress.domain }}
+      - name: mongodb.host
+        value: "mongodb-{{ .Release.Name }}"
+      - name: deployment.imageOverride.tag
+        value: {{ .Values.rs.tag }}
+    path: _infra/helm/securebanking-openbanking-uk-rs
+    repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-rs
+    targetRevision: {{ .Values.rs.branch }}
+  syncPolicy:
+    {{- toYaml .Values.spec.syncPolicy | nindent 4 }}
+{{- end }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -34,3 +34,6 @@ mongodb:
 externalCert:
   projectId: example-project
   defaultWildcard: true
+
+cdm:
+  enabled: "false"

--- a/argo/parent-app/templates/applications.yaml
+++ b/argo/parent-app/templates/applications.yaml
@@ -19,6 +19,9 @@ spec:
       - name: externalCert.defaultWildcard
         value: {{ .Values.externalCert.defaultWildcard | quote }}
         forceString: true
+      - name: cdm.enabled
+        value: {{ .Values.cdm.enabled | quote }}
+        forceString: true
       - name: spec.destination.namespace
         value: {{ .Release.Name }}
     path: argo/apps

--- a/argo/parent-app/values.yaml
+++ b/argo/parent-app/values.yaml
@@ -12,3 +12,6 @@ ingress:
 externalCert:
   projectId: example-project
   defaultWildcard: true
+
+cdm:
+  enabled: false


### PR DESCRIPTION
Add iam init to the argocd application definitions, this manifest is controlled by the `cdm.enabled` variable.
If the environment uses the CDM then we have to deploy the iam-init job to configure the realm on the cdm.

defaults to false as the CDK will deploy the iam-init job itself. the dev envrionments should not need to worry about configuration of am/idm.
