### PR TITLE
Add default wildcard

### DIFF
--- a/cluster/certificate/templates/cert-secret.yaml
+++ b/cluster/certificate/templates/cert-secret.yaml
@@ -15,7 +15,7 @@ spec:
     - key: dev-key
       name: tls.key
       version: latest
-    {{- else -}}
+    {{- else }}
     - key: {{ .Release.Namespace }}-crt
       name: tls.crt
       version: latest

--- a/cluster/certificate/templates/cert-secret.yaml
+++ b/cluster/certificate/templates/cert-secret.yaml
@@ -8,9 +8,18 @@ spec:
     type: kubernetes.io/tls
   projectId: {{ .Values.externalCert.projectId }}
   data:
+    {{- if .Values.defaultWildcardSecret }}
+    - key: dev-crt
+      name: tls.crt
+      version: latest
+    - key: dev-key
+      name: tls.key
+      version: latest
+    {{- else -}}
     - key: {{ .Release.Namespace }}-crt
       name: tls.crt
       version: latest
     - key: {{ .Release.Namespace }}-key
       name: tls.key
       version: latest
+    {{ end }}

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -1,3 +1,5 @@
+defaultWildcardSecret: false
+
 serviceAccount: default
 
 externalCert:


### PR DESCRIPTION
the default wildcard is needed as some namespaces share the `dev` wildcard.

cleanup from: https://github.com/SecureBankingAccessToolkit/sbat-cd/pull/53