### PR TITLE
Add condition to get crt without cdk when deploying to developer spec…

### DIFF
--- a/cluster/certificate/templates/cert-secret.yaml
+++ b/cluster/certificate/templates/cert-secret.yaml
@@ -16,10 +16,10 @@ spec:
       name: tls.key
       version: latest
     {{- else }}
-    - key: {{ .Release.Namespace }}-crt
+    - key: {{ .Values.namespace }}-crt
       name: tls.crt
       version: latest
-    - key: {{ .Release.Namespace }}-key
+    - key: {{ .Values.namespace }}-key
       name: tls.key
       version: latest
     {{ end }}

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -1,6 +1,7 @@
 defaultWildcardSecret: false
 
 serviceAccount: default
+namespace: default
 
 externalCert:
   projectId: example-project


### PR DESCRIPTION
Add condition to get crt without cdk when deploying to developer specific cdk namespace

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/294