### PR TITLE
294: Create a new variable that controls the cert sub-domain

### DIFF
--- a/cluster/certificate/README.md
+++ b/cluster/certificate/README.md
@@ -3,8 +3,19 @@ This helm chart has the purpose of bringing an SSL certificate from the google s
 
 ## Values
 
-| Value                        | description                                                           | default           |
+| Value    | description                          | default           |
 |------------------------------|-----------------------------------------------------------------------|-------------------|
-| externalCert.defaultWildcard | enable the default wildcard certificate relevant for the `dev` domain | `true`            |
+| defaultWildcard | enable the default wildcard certificate relevant for the `dev` domain | `true`            |
 | externalCert.secretName      | Name of the kubernetes secret to store the wildcard                   | `sslcert`         |
 | externalCert.projectId       | GCP project that stores the secrets                                   | `example-project` |
+| externalCert.certPrefix      | The prefix of the cert to pull from google secrets manager when defaultWildcard is false. |dev|
+
+## Example
+
+The following will create the `bohocode-cdk` namespace, and use the cluster/certificate chart to deploy a secret to sslcert in `bohocode-cdk` namespace. It will deploy the the secrets called `bohocode-crt` and `bohocode-key` from google secret manager to tls.crt and tls.key in the `sslcert` secret. 
+
+```
+helm upgrade cdk cluster/certificate --install --namespace bohocode-cdk --create-namespace --set namespace=bohocode-cdk --set externalCert.projectId=sbat-dev --set defaultWildcardSecret=false --set externalCert.certPrefix=bohocode
+```
+
+

--- a/cluster/certificate/templates/cert-secret.yaml
+++ b/cluster/certificate/templates/cert-secret.yaml
@@ -16,10 +16,10 @@ spec:
       name: tls.key
       version: latest
     {{- else }}
-    - key: {{ .Release.Namespace }}-crt
+    - key: {{ .Values.externalCert.certPrefix }}-crt
       name: tls.crt
       version: latest
-    - key: {{ .Release.Namespace }}-key
+    - key: {{ .Values.externalCert.certPrefix }}-key
       name: tls.key
       version: latest
     {{ end }}

--- a/cluster/certificate/values.yaml
+++ b/cluster/certificate/values.yaml
@@ -5,3 +5,4 @@ serviceAccount: default
 externalCert:
   projectId: example-project
   secretName: sslcert
+  certPrefix: dev


### PR DESCRIPTION
This chart used to always use the namespace as a prefix when trying to
obtain the correct cert from Google Secret Manager. e.g. when installing
CDK to bohocode-cdk namespace, this chart tried to pull the secret called
bohocode-cdk-crt and bohocode-cdk-key from google secret mangager.

However, the cert-renewal pipeline creates certs based on the sbat
namespace, e.g. bohocode, not the cdk namespace, e.g. bohcode-cdk. So
the pipeline would fail to find the bohocode-cdk-crt and key secrets and
the ingress would fall back to the default kubernetes cert.

The new variable externalCert.certPrefix can be used to set the cert
prefix using this chart, e.g.

```
helm upgrade cdk cluster/certificate --install --namespace bohocode-cdk --create-namespace \
--set externalCert.projectId=$PROJECT_ID --set defaultWildcardSecret=false --set externalCert.certPrefix=bohocode
```

Will install the CDK to the namespace bohocode-cdk and use secrets from
Google Secret Manager called bohocode-crt and bohocode-key to get the
sslcert secret. This secret must be created before installing this
chart. The cert can be created using the certificate-renewal pipeline.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/294