### PR TITLE
Bump up mongodb version to 12.1.15 

### DIFF
--- a/argo/apps/templates/mongodb.yaml
+++ b/argo/apps/templates/mongodb.yaml
@@ -20,6 +20,6 @@ spec:
       - name: auth.enabled
         value: "{{ .Values.mongodb.auth.enabled }}"
     repoURL: https://charts.bitnami.com/bitnami
-    targetRevision: 10.15.1
+    targetRevision: 12.1.15
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}


### PR DESCRIPTION
Bump up mongodb version to 12.1.15 as the old version is no longer found on bitnami. As a result the rs service is unable to start.