### PR TITLE
294: Remove defaultWildcardSecret chart value

### DIFF
--- a/argo/apps/templates/namespace-init.yaml
+++ b/argo/apps/templates/namespace-init.yaml
@@ -16,6 +16,8 @@ spec:
       parameters:
       - name: externalCert.projectId
         value: {{ .Values.externalCert.projectId }}
+      - name: externalCert.certPrefix
+        value: {{ .Values.externalCert.certPrefix }}
     path: cluster/certificate
     repoURL: https://github.com/SecureBankingAccessToolkit/sbat-cd
     targetRevision: {{ .Values.spec.source.targetRevision }}

--- a/cluster/certificate/README.md
+++ b/cluster/certificate/README.md
@@ -1,11 +1,12 @@
 ## namespace-setup
 This helm chart has the purpose of bringing an SSL certificate from the google secrets manger. We use this to limit our dependency on cert-manager. Our namespaces are created and destroyed frequently and cert-manager has the tendency of requesting new prod letsencrypt certificates which regularly gives us a 429 throttle for cert requests.
 
+By default, the chart will use the dev-crt and dev-key secrets from secret manager, but this may be over-ridden usign the externalCert.certPrefix value (see below).
+
 ## Values
 
 | Value    | description                          | default           |
 |------------------------------|-----------------------------------------------------------------------|-------------------|
-| defaultWildcard | enable the default wildcard certificate relevant for the `dev` domain | `true`            |
 | externalCert.secretName      | Name of the kubernetes secret to store the wildcard                   | `sslcert`         |
 | externalCert.projectId       | GCP project that stores the secrets                                   | `example-project` |
 | externalCert.certPrefix      | The prefix of the cert to pull from google secrets manager when defaultWildcard is false. |dev|

--- a/cluster/certificate/templates/cert-secret.yaml
+++ b/cluster/certificate/templates/cert-secret.yaml
@@ -8,18 +8,9 @@ spec:
     type: kubernetes.io/tls
   projectId: {{ .Values.externalCert.projectId }}
   data:
-    {{- if .Values.defaultWildcardSecret }}
-    - key: dev-crt
-      name: tls.crt
-      version: latest
-    - key: dev-key
-      name: tls.key
-      version: latest
-    {{- else }}
     - key: {{ .Values.externalCert.certPrefix }}-crt
       name: tls.crt
       version: latest
     - key: {{ .Values.externalCert.certPrefix }}-key
       name: tls.key
       version: latest
-    {{ end }}


### PR DESCRIPTION
With the use of the recently introduced externalCert.certPrefix we no
longer need the defaultWildcardSecret value. If no
externalCert.certPrefix is set then the default value used is 'dev'.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/294