### PR TITLE
276: Deploy initializers into sbat namespaces using argocd

### DIFF
--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -20,8 +20,14 @@ spec:
       parameters:
       - name: environment.fr_platform.type
         value: {{ .Values.environment.type }}
-      - name: iam_initializer_image_location
-        value: eu.gcr.io/sbat-gcr-develop/securebanking/secureopenbanking-uk-iam-initializer:latest
+      - name: deployment.imageOverride.enabled
+        value: true
+      - name: deployment.imageOverride.repo
+        value: eu.gcr.io/sbat-gcr-develop/securebanking/
+      - name: deployment.imageOverride.iam_initializer_image_name
+        value: secureopenbanking-uk-iam-initializer
+      - name: deployment.imageOverride.iam-init.tag
+        value: {{ Values.iam-init.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
     targetRevision: master

--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -1,11 +1,11 @@
 # This initializer pod will be deployed in the namespace with the environment type = 'FIDC'
 # Otherwise, currently this pod will be deployed in cdk namespace only
 # @See the pipeline initialise, step 'install_initializer_cron_job'
-{{- if eq .Values.environment.type "FIDC" }}
+
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: iam-init-{{ .Release.Name }}
+  name: iam-initialiser-{{ .Release.Name }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   finalizers:
@@ -18,11 +18,12 @@ spec:
   source:
     helm:
       parameters:
-      - name: environment.type
+      - name: environment.fr_platform.type
         value: {{ .Values.environment.type }}
-    path: _infra/helm/securebanking-openbanking-uk-fidc-initializer
+      - name: iam_initializer_image_location
+        value: eu.gcr.io/sbat-gcr-develop/securebanking/secureopenbanking-uk-iam-initializer:latest
+    path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: HEAD
+    targetRevision: master
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}
-{{- end }}

--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -27,9 +27,9 @@ spec:
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
       - name: deployment.imageOverride.iam_initializer_image_tag
-        value: {{ Values.iam-init.tag }}
+        value: {{ .Values.iam-init.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: master
+    targetRevision: {{ .Values.iam-init.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -26,7 +26,7 @@ spec:
         value: eu.gcr.io/sbat-gcr-develop/securebanking/
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
-      - name: deployment.imageOverride.iam-init.tag
+      - name: deployment.imageOverride.iam_initializer_image_tag
         value: {{ Values.iam-init.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer

--- a/argo/apps/templates/sbat-test-user-init.yaml
+++ b/argo/apps/templates/sbat-test-user-init.yaml
@@ -1,11 +1,11 @@
 # This initializer pod will be deployed in the namespace with the environment type = 'FIDC'
 # Otherwise, currently this pod will be deployed in cdk namespace only
 # @See the pipeline initialise, step 'install_initializer_cron_job'
-{{- if eq .Values.environment.type "FIDC" }}
+
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: iam-init-{{ .Release.Name }}
+  name: test-data-initialiser-{{ .Release.Name }}
   annotations:
     argocd.argoproj.io/sync-wave: "2"
   finalizers:
@@ -18,11 +18,12 @@ spec:
   source:
     helm:
       parameters:
-      - name: environment.type
+      - name: environment.fr_platform.type
         value: {{ .Values.environment.type }}
-    path: _infra/helm/securebanking-openbanking-uk-fidc-initializer
-    repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: HEAD
+      - name: test_data_initializer_image_location
+        value: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-test-data-initializer:latest
+    path: _infra/helm/securebanking-test-data-initializer
+    repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-test-data-initializer
+    targetRevision: master
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}
-{{- end }}

--- a/argo/apps/templates/sbat-test-user-init.yaml
+++ b/argo/apps/templates/sbat-test-user-init.yaml
@@ -20,10 +20,16 @@ spec:
       parameters:
       - name: environment.fr_platform.type
         value: {{ .Values.environment.type }}
-      - name: test_data_initializer_image_location
-        value: eu.gcr.io/sbat-gcr-develop/securebanking/securebanking-test-data-initializer:latest
+      - name: deployment.imageOverride.enabled
+        value: true
+      - name: deployment.imageOverride.repo
+        value: eu.gcr.io/sbat-gcr-develop/securebanking/
+      - name: deployment.imageOverride.test_data_initializer_image_name
+        value: securebanking-test-data-initializer
+      - name: deployment.imageOverride.test_data_initializer_tag
+        value: {{ .Values.test-user-init.tag }}
     path: _infra/helm/securebanking-test-data-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-test-data-initializer
-    targetRevision: master
+    targetRevision: {{ .Values.test-user-init.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -38,6 +38,14 @@ ig:
   tag: latest
   branch: HEAD
 
+iam-init:
+  tag: latest
+  branch: HEAD
+
+test-user-init:
+  tag: latest
+  branch: HEAD
+
 mongodb:
   auth:
     enabled: false


### PR DESCRIPTION
Add two new charts to argocd config that will deploy;

- The `securebanking-openbanking-uk-fidc-initializer` which will
initialize the FR Platform
- The `securebanking-openbanking-test-data-initializer` which will
  create test users and data in the platform/sbat instance such that the
  functional tests will be able to be run.

Issue: https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/276