### PR TITLE
523: Update ig version references

### DIFF
--- a/argo/apps/templates/ig.yaml
+++ b/argo/apps/templates/ig.yaml
@@ -12,7 +12,7 @@ spec:
     server: https://kubernetes.default.svc
   project: default
   source:
-    path: kustomize/overlay/7.0/obdemo-bank/{{ .Values.spec.destination.namespace }}
+    path: kustomize/overlay/7.1.0/securebanking/{{ .Values.spec.destination.namespace }}
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-gateway
     targetRevision: {{ .Values.ig.branch }}
     kustomize:


### PR DESCRIPTION
- Updated ig helm template kustomize path to use the new one pointed to 7.1.0/securebanking
Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/523