### PR TITLE
276: Fxing helm parameters passed by argo to be strings (this is the only type supported)

### DIFF
--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -21,7 +21,7 @@ spec:
       - name: environment.fr_platform.type
         value: {{ .Values.environment.type }}
       - name: deployment.imageOverride.enabled
-        value: true
+        value: "true"
       - name: deployment.imageOverride.repo
         value: eu.gcr.io/sbat-gcr-develop/securebanking/
       - name: deployment.imageOverride.iam_initializer_image_name

--- a/argo/apps/templates/sbat-test-user-init.yaml
+++ b/argo/apps/templates/sbat-test-user-init.yaml
@@ -21,7 +21,7 @@ spec:
       - name: environment.fr_platform.type
         value: {{ .Values.environment.type }}
       - name: deployment.imageOverride.enabled
-        value: true
+        value: "true"
       - name: deployment.imageOverride.repo
         value: eu.gcr.io/sbat-gcr-develop/securebanking/
       - name: deployment.imageOverride.test_data_initializer_image_name


### PR DESCRIPTION
https://github.com/SecureBankingAccessToolkit/SecureBankingAccessToolkit/issues/276