### PR TITLE
276: Make PR push to argo deployment work correctly

### DIFF
--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -27,9 +27,9 @@ spec:
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
       - name: deployment.imageOverride.iam_initializer_image_tag
-        value: {{ .Values.iamInit.tag }}
+        value: {{ .Values.iam-initialiser.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: {{ .Values.iamInit.branch }}
+    targetRevision: {{ .Values.iam-initialiser.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}


### PR DESCRIPTION
I was using the wrong service name in the argocd template for the iam-initialiser

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/276