### PR TITLE
276: Fix broken initialise-sbat-namespaces pipeline

### DIFF
--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -27,9 +27,9 @@ spec:
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
       - name: deployment.imageOverride.iam_initializer_image_tag
-        value: {{ .Values.iam-initialiser.tag }}
+        value: {{ .Values.iamInitialiser.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: {{ .Values.iam-initialiser.branch }}
+    targetRevision: {{ .Values.iamInitialiser.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}


### PR DESCRIPTION
'-' is not a valid character when passing args to argo

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/276