### PR TITLE
276: Fix failing initialize-sbat-namespaces pipeline

### DIFF
--- a/argo/apps/templates/sbat-iam-init.yaml
+++ b/argo/apps/templates/sbat-iam-init.yaml
@@ -27,9 +27,9 @@ spec:
       - name: deployment.imageOverride.iam_initializer_image_name
         value: secureopenbanking-uk-iam-initializer
       - name: deployment.imageOverride.iam_initializer_image_tag
-        value: {{ .Values.iamInitialiser.tag }}
+        value: {{ .Values.iam-initialiser.tag }}
     path: _infra/helm/securebanking-openbanking-uk-iam-initializer
     repoURL: https://github.com/SecureBankingAccessToolkit/securebanking-openbanking-uk-fidc-initializer
-    targetRevision: {{ .Values.iamInitialiser.branch }}
+    targetRevision: {{ .Values.iam-initialiser.branch }}
   syncPolicy:
     {{- toYaml .Values.spec.syncPolicy | nindent 4 }}

--- a/argo/apps/values.yaml
+++ b/argo/apps/values.yaml
@@ -38,7 +38,7 @@ ig:
   tag: latest
   branch: HEAD
 
-iamInit:
+iam-initialiser:
   tag: latest
   branch: HEAD
 


### PR DESCRIPTION
The values expected by the argocd chart didn't accept what we were passing. Stars not alligned...

Issue: https://github.com/securebankingaccesstoolkit/securebankingaccesstoolkit/issues/276